### PR TITLE
Change the insertion sort solustion

### DIFF
--- a/chapters/chapter-2-sorting/2.1-elementary-sorts/insertion.js
+++ b/chapters/chapter-2-sorting/2.1-elementary-sorts/insertion.js
@@ -8,11 +8,13 @@ console.log('> input: ' + input);
 // insertion
 function insertion(input) {
   for(var i = 1, len = input.length; i < len; i++) {
-    for(var j = i; j > 0; j--) {
-      if(input[j] < input[j - 1]) {
-        input[j] = [input[j - 1], input[j - 1] = input[j]][0];
-      }
+    var insertion = input[i];
+    var j = i;
+    while (j > 0 && insertion < input[j-1]) {
+      input[j] = input[j-1];  
+      j--;
     }
+      input[j] = insertion;
   }
   return input;
 }


### PR DESCRIPTION
插入排序的传统实现方式应该是确定要插入的元素并向前比较，到合适的位置后，数组向右移位，同时插入合适的位置。算法（第四版）中文版描述如下：

> 通常人们整理桥牌的方法是一张一张的来，将每一张牌插入到其他已经有序的牌中的适当位置。在计算机的实现中，为了给更小的元素腾出空间，我们需要将其余所有元素在插入之前都向右移动一位。

而原本的实现方式是通过一次次与前面的较大的数交换到合适的位置的，这样不太符合传统的插入排序实现原理。
